### PR TITLE
fix(github-action): fix path of artifact file

### DIFF
--- a/.github/workflows/render-video.yml
+++ b/.github/workflows/render-video.yml
@@ -25,5 +25,5 @@ jobs:
           WORKFLOW_INPUT: ${{ toJson(github.event.inputs) }}
       - uses: actions/upload-artifact@v2
         with:
-          name: out.mp4
-          path: out.mp4
+          name: out
+          path: out/video.mp4


### PR DESCRIPTION
`out.mp4`  in not an existing file so github action artifact won't be uploaded.
In order to make it work, we have to pass existing path.

See [related doc on artifacts](https://github.com/actions/upload-artifact)

This PR fixes the artifact creation.

If you are ok with this change I could do it in the other template repositories.